### PR TITLE
feature-dataset-parsing

### DIFF
--- a/admin/class-visualbudget-dataset.php
+++ b/admin/class-visualbudget-dataset.php
@@ -208,4 +208,33 @@ class VisualBudget_Dataset {
         return VISUALBUDGET_UPLOAD_PATH . $this->properties['original_filename'];
     }
 
+    // Vertical dimension of the dataset
+    public function num_rows() {
+        return count($this->data);
+    }
+
+    // Horizontal dimension of the dataset
+    public function num_cols() {
+        return count($this->data[0]);
+    }
+
+    // A preview of the dataset
+    public function corner() {
+        $rows = 4;
+        $cols = 5;
+        $corner = array_slice(
+                array_map(function($i) use ($cols) {
+                    return array_slice($i, 0, $cols);
+                }, $this->data),
+            0, $rows);
+        return $corner;
+    }
+
+    // Get the properties of the dataset
+    public function get_properties() {
+        return $this->properties;
+    }
+
+
+
 }

--- a/admin/class-visualbudget-dataset.php
+++ b/admin/class-visualbudget-dataset.php
@@ -352,9 +352,8 @@ class VisualBudget_Dataset {
     }
 
     // A preview of the dataset
-    public function corner() {
-        $rows = 4;
-        $cols = 5;
+    // Display $rows rows and $cols columns from the top left
+    public function corner($rows = 4, $cols = 5) {
         $corner = array_slice(
                 array_map(function($i) use ($cols) {
                     return array_slice($i, 0, $cols);

--- a/admin/partials/visualbudget-admin-display-datasets.php
+++ b/admin/partials/visualbudget-admin-display-datasets.php
@@ -23,8 +23,11 @@ submit_button('Upload file');
 -->
 <h2>My datasets</h2>
 <div class='bootstrap-wrapper'>
+<p class='alert alert-danger'><em>Caveat emptor &mdash;</em> datasets are not yet validated upon upload.</p>
 <?php
 $datasets = $this->filemanager->get_datasets_inventory();
+
+// $datasets = $this->datasets;
 
 if (!empty($datasets)) {
     // Just get the IDs of the datasets
@@ -62,7 +65,7 @@ if (!empty($datasets)) {
         echo '<br/>';
         echo $rows . ' rows &times; ' . $cols . ' columns';
         echo '<br/>';
-        echo 'added ' . date('H:i', $number) . ' on '. date('j M Y', $number);
+        echo 'added ' . date('H:i', $meta['created']) . ' on '. date('j M Y', $meta['created']);
         echo '<br/>';
         echo '<small>JSON: <a href="' . VISUALBUDGET_UPLOAD_URL . $meta['filename'] . '">'
                     . $meta['filename'] . '</a></small>';

--- a/admin/partials/visualbudget-admin-display-datasets.php
+++ b/admin/partials/visualbudget-admin-display-datasets.php
@@ -25,66 +25,45 @@ submit_button('Upload file');
 <div class='bootstrap-wrapper'>
 <p class='alert alert-danger'><em>Caveat emptor &mdash;</em> datasets are not yet validated upon upload.</p>
 <?php
-$datasets = $this->filemanager->get_datasets_inventory();
 
-// $datasets = $this->datasets;
+$datasets = $this->datasets;
 
-if (!empty($datasets)) {
-    // Just get the IDs of the datasets
-    $numbers = array_map(function($i) {
-            return explode('_', $i['name'])[0];
-        }, $datasets);
+// Test to see if there are any datasets
+if (empty($datasets)) {
 
-    // We'll have duplicates, so get a unique set
-    $numbers = array_unique($numbers);
+    // If not, say so
+    echo 'There are no datasets.';
 
-    // Now print some information for each.
-    foreach ($numbers as $number) {
+} else {
 
-        $meta = $this->filemanager->read_file($number . '_meta.json');
-        $meta = json_decode($meta, true);
+    // If there are datasets, print some information for each one
+    foreach ($datasets as $dataset) {
+        $props = $dataset->get_properties();
 
-        $data = $this->filemanager->read_file($number . '_data.json');
-        $data = json_decode($data, true);
-        $rows = count($data);
-        $cols = count($data[0]);
-
-        $corner = array_slice(
-                array_map(function($i) {
-                    return array_slice($i, 0, 5);
-                }, $data),
-            0, 4);
-
-
-        // echo '<hr/>';
         echo '<br/>';
-        echo '<div class="row">';
-        echo '<div class="col-md-5">';
-        echo '<strong>' . $meta['uploaded_name'] . '</strong>';
-        echo ' [<a href="?' . http_build_query($_GET) . '&delete=' . $number . '">delete</a>]';
+        echo '<div class="row"><div class="col-md-5">';
+        echo '<strong>' . $props['uploaded_name'] . '</strong>';
+        echo ' [<a href="?' . http_build_query($_GET) . '&delete=' . $props['id'] . '">delete</a>]';
         echo '<br/>';
-        echo $rows . ' rows &times; ' . $cols . ' columns';
+        echo $dataset->num_rows() . ' rows &times; ' . $dataset->num_cols() . ' columns';
         echo '<br/>';
-        echo 'added ' . date('H:i', $meta['created']) . ' on '. date('j M Y', $meta['created']);
+        echo 'added ' . date('H:i', $props['created']) . ' on '. date('j M Y', $props['created']);
         echo '<br/>';
-        echo '<small>JSON: <a href="' . VISUALBUDGET_UPLOAD_URL . $meta['filename'] . '">'
-                    . $meta['filename'] . '</a></small>';
+        echo '<small>JSON: <a href="' . VISUALBUDGET_UPLOAD_URL . $props['filename'] . '">'
+                    . $props['filename'] . '</a></small>';
         echo '<br/>';
-        echo '<small>Original: <a href="' . VISUALBUDGET_UPLOAD_URL . $meta['original_filename'] . '">'
-                    . $meta['original_filename'] . '</a></small>';
-        echo '</div>';
-        echo '<div class="col-md-7">';
-        $rows = $meta['corner'];
+        echo '<small>Original: <a href="' . VISUALBUDGET_UPLOAD_URL . $props['original_filename'] . '">'
+                    . $props['original_filename'] . '</a></small>';
+        echo '</div><div class="col-md-7">';
+        $corner = $dataset->corner();
         // table code from http://stackoverflow.com/a/37727144/1516307
         $tbody = array_reduce(array_slice($corner,1), function($a, $b){return $a.="<tr><td>".implode("</td><td>",$b)."</td></tr>";});
         $thead = "<tr><th>" . implode("</th><th>", array_values($corner[0])) . "</th></tr>";
 
         echo "<small><table class='table table-condensed table-responsive'>\n$thead\n$tbody\n</table></small>";
-        echo '</div>';
-        echo '</div>';
+        echo '</div></div>';
     }
-} else {
-    echo 'There are no datasets.';
 }
+
 ?>
 </div>

--- a/admin/partials/visualbudget-admin-display-datasets.php
+++ b/admin/partials/visualbudget-admin-display-datasets.php
@@ -55,7 +55,7 @@ if (empty($datasets)) {
         echo '<small>Original: <a href="' . VISUALBUDGET_UPLOAD_URL . $props['original_filename'] . '">'
                     . $props['original_filename'] . '</a></small>';
         echo '</div><div class="col-md-7">';
-        $corner = $dataset->corner();
+        $corner = VisualBudget_Dataset::infer_levels($dataset->corner());
         // table code from http://stackoverflow.com/a/37727144/1516307
         $tbody = array_reduce(array_slice($corner,1), function($a, $b){return $a.="<tr><td>".implode("</td><td>",$b)."</td></tr>";});
         $thead = "<tr><th>" . implode("</th><th>", array_values($corner[0])) . "</th></tr>";


### PR DESCRIPTION
Two big features of the dataset class now work:
- LEVELs can be inferred robustly (independent of column order)
- Datasets can be queried for certain LEVELs

The first is required for the second. I can now say

```
// $x is a VisualBudget_Dataset object
$result = $x.query(array('schools', 'utilities', 'water'));
```

to get all of the rows of `$x` in which LEVEL1 is "Schools", LEVEL2 is "Utilities", and LEVEL3 is "Water". Column order is irrelevant. Matching is case-insensitive.
