### PR TITLE
fix-random-int

### DIFF
--- a/vis/vis.php
+++ b/vis/vis.php
@@ -5,7 +5,7 @@
  */
 
 if ( ! isset($_GET['rand']) ) {
-    $_GET['rand'] = random_int(PHP_INT_MIN, PHP_INT_MAX);
+    $_GET['rand'] = mt_rand(0, PHP_INT_MAX);
 }
 $query_string = http_build_query($_GET);
 $hash = hash('crc32', $query_string);


### PR DESCRIPTION
`random_int` is PHP 7+. Using `mt_rand` instead.

Closes #61.
